### PR TITLE
Replace "application" plugin to "java" in samples

### DIFF
--- a/samples/build.gradle.kts
+++ b/samples/build.gradle.kts
@@ -20,7 +20,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 plugins {
-    application
+    java
 }
 
 repositories {
@@ -29,10 +29,6 @@ repositories {
 
 dependencies {
     implementation(project(":lib"))
-}
-
-application {
-    mainClass.set("com.dwolfnineteen.samples.Paper")
 }
 
 java {


### PR DESCRIPTION
### Changes
- ❌ Internal
- ❌ Interface (affects end-user code) 
- ❌ Docs
- ❌ Metadata (README, copyright, Git files, files in `.github`, etc)
- ✅ Other: Change Gradle plugin in samples
### Description
Replace `application` plugin to `java` in samples. We don't need to run anything there!
