### PR TITLE
Add simple container for FileOutputStream

### DIFF
--- a/lib/src/main/java/com/dwolfnineteen/jpdapi/utils/FileManager.java
+++ b/lib/src/main/java/com/dwolfnineteen/jpdapi/utils/FileManager.java
@@ -1,0 +1,17 @@
+package com.dwolfnineteen.jpdapi.utils;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
+
+public class FileManager {
+    public static void toFile(byte[] buffer, @NotNull String outputPath) {
+        try (FileOutputStream file = new FileOutputStream(outputPath)) {
+            file.write(buffer, 0, buffer.length);
+
+        } catch (IOException exception) {
+            throw new RuntimeException(exception);
+        }
+    }
+}


### PR DESCRIPTION
### Changes
- ✅ Internal
- ❌ Interface (affects end-user code)
- ❌ Gradle (wrapper, scripts, dependencies)
- ❌ Docs
- ❌ Metadata (README, copyright, Git files, files in `.github`)
- ❌ Other: ...
### Description
Add simple container for `FileOutputStream`. This will remove frequently duplicated code (in the future).
