### PR TITLE
Make APIException abstract

### DIFF
--- a/lib/src/main/java/com/dwolfnineteen/jpdapi/exceptions/APIException.java
+++ b/lib/src/main/java/com/dwolfnineteen/jpdapi/exceptions/APIException.java
@@ -23,7 +23,7 @@ package com.dwolfnineteen.jpdapi.exceptions;
 
 import org.jetbrains.annotations.NotNull;
 
-public class APIException extends RuntimeException {
+public abstract class APIException extends RuntimeException {
     public APIException(@NotNull String message) {
         super(message);
     }


### PR DESCRIPTION
### Changes
- ❌Internal
- ✅ Interface (affects end-user code)
- ❌ Gradle (wrapper, scripts, dependencies)
- ❌ Docs
- ❌ Metadata (README, copyright, Git files, files in `.github`)
- ❌ Other: ...
### Description
Make `APIException` abstract. This change break `APIException` instance creations.
