### PR TITLE
Add JDK, Gradle and CI status badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 # JPD-API
 ![JDP-API](banner.png)
 --
+![JDK](https://img.shields.io/badge/Minimum_JDK-8-white?logo=openjdk&link=https%3A%2F%2Fadoptium.net%2Ftemurin%2Freleases%2F)
+![Gradle](https://img.shields.io/badge/Built_with-Gradle-white?logo=gradle&link=https%3A%2F%2Fgradle.org%2F)
+[![CI](https://github.com/DWolf-19/JPD-API/actions/workflows/ci.yml/badge.svg)](https://github.com/DWolf-19/JPD-API/actions/workflows/ci.yml)
+
 A lightweight Java wrapper for the Paper downloads API.


### PR DESCRIPTION
### Changes
- ❌ Internal
- ❌ Interface (affects end-user code)
- ❌ Gradle (wrapper, scripts, dependencies)
- ❌ Docs
- ✅ Metadata (README, copyright, Git files, files in `.github`)
- ❌ Other: ...
### Description
Add "Minimum JDK" / "Built with Gradle" and CI status badges to README.
