### PR TITLE
Revert "Add JDK, Gradle and CI status badges to README (#45)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,4 @@
 # JPD-API
 ![JDP-API](banner.png)
 --
-![JDK](https://img.shields.io/badge/Minimum_JDK-8-white?logo=openjdk&link=https%3A%2F%2Fadoptium.net%2Ftemurin%2Freleases%2F)
-![Gradle](https://img.shields.io/badge/Built_with-Gradle-white?logo=gradle&link=https%3A%2F%2Fgradle.org%2F)
-[![CI](https://github.com/DWolf-19/JPD-API/actions/workflows/ci.yml/badge.svg)](https://github.com/DWolf-19/JPD-API/actions/workflows/ci.yml)
-
 A lightweight Java wrapper for the Paper downloads API.


### PR DESCRIPTION
### Changes
- ❌ Internal
- ❌ Interface (affects end-user code)
- ❌ Gradle (wrapper, scripts, dependencies)
- ❌ Docs
- ✅ Metadata (README, copyright, Git files, files in `.github`)
- ❌ Other: ...
### Description
This reverts commit 9ba3e25936fc9f470cc300a132880d5215fb8d62.

Minimum JDK requirements will be located in a separate section in README. Other icons are useless.